### PR TITLE
GitIgnore modified to remove DS_Store files from MAC OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ target
 *.iws
 *.ipr
 .idea
-
+.DS_Store


### PR DESCRIPTION
The following modification ignores ".DS_Store" files of MAC OS X.